### PR TITLE
Add battery abstraction and charge/discharge cooldown

### DIFF
--- a/src/battery.rs
+++ b/src/battery.rs
@@ -1,0 +1,129 @@
+use crate::models::{ControlDecision, ControlMode, ZendureProperties};
+use crate::zendure::ZendureClient;
+
+/// Current battery state, used by the controller to make decisions.
+#[derive(Debug, Clone)]
+pub struct BatteryState {
+    /// State of charge (%), 0–100.
+    pub soc: u32,
+    /// Maximum discharge/inverter output power (W).
+    pub max_discharge_power: i32,
+    /// Maximum charge power (W).
+    pub max_charge_power: i32,
+}
+
+impl BatteryState {
+    pub fn from_properties(props: &ZendureProperties) -> Self {
+        Self {
+            soc: props.electric_level.unwrap_or(0),
+            max_discharge_power: props.inverse_max_power.unwrap_or(800) as i32,
+            max_charge_power: props.charge_max_limit.unwrap_or(2400) as i32,
+        }
+    }
+}
+
+/// Errors that can occur when interacting with a battery.
+#[derive(Debug)]
+#[allow(dead_code)]
+pub enum BatteryError {
+    /// HTTP / network error communicating with the device.
+    Http(reqwest::Error),
+    /// Any other error.
+    Other(String),
+}
+
+impl std::fmt::Display for BatteryError {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            BatteryError::Http(e) => write!(f, "HTTP error: {e}"),
+            BatteryError::Other(msg) => write!(f, "{msg}"),
+        }
+    }
+}
+
+impl std::error::Error for BatteryError {}
+
+impl From<reqwest::Error> for BatteryError {
+    fn from(e: reqwest::Error) -> Self {
+        BatteryError::Http(e)
+    }
+}
+
+/// Abstraction over a battery system (real Zendure device or mock).
+pub trait Battery {
+    /// Read current battery state (SoC, limits).
+    fn get_state(
+        &self,
+    ) -> impl std::future::Future<Output = Result<BatteryState, BatteryError>> + Send;
+
+    /// Apply a control decision to the battery.
+    #[allow(dead_code)]
+    fn apply(
+        &self,
+        decision: &ControlDecision,
+    ) -> impl std::future::Future<Output = Result<(), BatteryError>> + Send;
+}
+
+impl Battery for ZendureClient {
+    async fn get_state(&self) -> Result<BatteryState, BatteryError> {
+        let report = self.get_properties().await?;
+        Ok(BatteryState::from_properties(&report.properties))
+    }
+
+    async fn apply(&self, decision: &ControlDecision) -> Result<(), BatteryError> {
+        let props = match decision.mode {
+            ControlMode::Charge => serde_json::json!({
+                "acMode": 1,
+                "inputLimit": decision.power_watts,
+            }),
+            ControlMode::Discharge => serde_json::json!({
+                "acMode": 2,
+                "outputLimit": decision.power_watts,
+            }),
+            ControlMode::Idle => serde_json::json!({
+                "acMode": 1,
+                "inputLimit": 0,
+            }),
+        };
+        self.write_properties(props).await?;
+        Ok(())
+    }
+}
+
+#[cfg(test)]
+pub mod mock {
+    use super::*;
+    use std::sync::Mutex;
+
+    /// A mock battery for testing. State is configurable and all applied
+    /// decisions are recorded for assertions.
+    pub struct MockBattery {
+        state: Mutex<BatteryState>,
+        pub applied: Mutex<Vec<ControlDecision>>,
+    }
+
+    impl MockBattery {
+        pub fn new(state: BatteryState) -> Self {
+            Self {
+                state: Mutex::new(state),
+                applied: Mutex::new(Vec::new()),
+            }
+        }
+
+        /// Update the battery state (e.g. change SoC mid-test).
+        pub fn set_state(&self, state: BatteryState) {
+            *self.state.lock().unwrap() = state;
+        }
+    }
+
+    impl Battery for MockBattery {
+        async fn get_state(&self) -> Result<BatteryState, BatteryError> {
+            Ok(self.state.lock().unwrap().clone())
+        }
+
+        async fn apply(&self, decision: &ControlDecision) -> Result<(), BatteryError> {
+            self.applied.lock().unwrap().push(decision.clone());
+            Ok(())
+        }
+    }
+}

--- a/src/controller.rs
+++ b/src/controller.rs
@@ -1,38 +1,119 @@
+use std::time::{Duration, Instant};
+
 use chrono::{Local, Timelike};
 
-use crate::models::{ControlDecision, ControlMode, ZendureProperties};
+use crate::battery::BatteryState;
+use crate::models::{ControlDecision, ControlMode};
 
 const MAX_CHARGE_POWER: i32 = 2400;
 const MIN_POWER_THRESHOLD: i32 = 50;
 const DISCHARGE_START_HOUR: u32 = 17;
 const DISCHARGE_END_HOUR: u32 = 7;
 
-/// Battery limits read from the device at startup.
-pub struct BatteryLimits {
-    /// Maximum discharge/inverter output power (W).
-    /// From `inverseMaxPower` on the device (e.g. 800).
-    pub max_discharge_power: i32,
+/// Minimum time the battery must stay in a mode before switching between
+/// charge and discharge. Switching to/from idle is always allowed.
+const MIN_MODE_DURATION: Duration = Duration::from_secs(5 * 60);
+
+pub struct Controller {
+    last_mode: ControlMode,
+    last_mode_change: Instant,
+    min_mode_duration: Duration,
 }
 
-impl BatteryLimits {
-    pub fn from_properties(props: &ZendureProperties) -> Self {
+impl Controller {
+    pub fn new() -> Self {
         Self {
-            max_discharge_power: props.inverse_max_power.unwrap_or(800) as i32,
+            last_mode: ControlMode::Idle,
+            // Allow immediate first transition
+            last_mode_change: Instant::now() - MIN_MODE_DURATION,
+            min_mode_duration: MIN_MODE_DURATION,
         }
+    }
+
+    pub fn decide(
+        &mut self,
+        grid_power: f64,
+        solar_power: f64,
+        battery: &BatteryState,
+    ) -> ControlDecision {
+        let hour = Local::now().hour();
+        self.decide_at_hour(grid_power, solar_power, battery, hour)
+    }
+
+    fn decide_at_hour(
+        &mut self,
+        grid_power: f64,
+        solar_power: f64,
+        battery: &BatteryState,
+        hour: u32,
+    ) -> ControlDecision {
+        let raw = raw_decide(grid_power, solar_power, battery, hour);
+        self.apply_cooldown(raw)
+    }
+
+    fn apply_cooldown(&mut self, decision: ControlDecision) -> ControlDecision {
+        let dominated = is_opposing_switch(self.last_mode, decision.mode);
+
+        if dominated && self.last_mode_change.elapsed() < self.min_mode_duration {
+            // Suppress charge↔discharge toggle — go idle instead
+            let idle = ControlDecision {
+                mode: ControlMode::Idle,
+                power_watts: 0,
+                reason: format!(
+                    "Cooldown: suppressed {} (was {} for {:.0}s, min {}s)",
+                    decision.mode,
+                    self.last_mode,
+                    self.last_mode_change.elapsed().as_secs_f64(),
+                    self.min_mode_duration.as_secs(),
+                ),
+                grid_power: decision.grid_power,
+                solar_power: decision.solar_power,
+            };
+            // Don't update last_mode — we're waiting for the cooldown to expire
+            return idle;
+        }
+
+        if decision.mode != self.last_mode {
+            self.last_mode = decision.mode;
+            self.last_mode_change = Instant::now();
+        }
+
+        decision
     }
 }
 
-/// Pure function: given current grid and solar readings, decide what the battery should do.
-///
-/// `grid_power` is the net grid power (W).
-///   Positive = importing from grid, negative = exporting to grid.
-/// `solar_power` is the current solar production (W), always >= 0.
-/// `limits` contains the battery's actual power limits from the device.
-pub fn decide(grid_power: f64, solar_power: f64, limits: &BatteryLimits) -> ControlDecision {
+/// Returns true if switching from `prev` to `next` is a charge↔discharge
+/// toggle that should be rate-limited.
+fn is_opposing_switch(prev: ControlMode, next: ControlMode) -> bool {
+    matches!(
+        (prev, next),
+        (ControlMode::Charge, ControlMode::Discharge)
+            | (ControlMode::Discharge, ControlMode::Charge)
+    )
+}
+
+/// Stateless decision logic, without cooldown protection.
+fn raw_decide(
+    grid_power: f64,
+    solar_power: f64,
+    battery: &BatteryState,
+    hour: u32,
+) -> ControlDecision {
+    // Battery full — don't charge
+    if battery.soc >= 100 {
+        return discharge_or_idle(
+            grid_power,
+            solar_power,
+            battery,
+            hour,
+            "Battery full (100%)",
+        );
+    }
+
     // If we're exporting to the grid, we have excess solar — charge the battery
     if grid_power < -(MIN_POWER_THRESHOLD as f64) {
         let excess = (-grid_power) as i32;
-        let charge_power = excess.min(MAX_CHARGE_POWER);
+        let charge_power = excess.min(MAX_CHARGE_POWER).min(battery.max_charge_power);
         return ControlDecision {
             mode: ControlMode::Charge,
             power_watts: charge_power,
@@ -42,29 +123,226 @@ pub fn decide(grid_power: f64, solar_power: f64, limits: &BatteryLimits) -> Cont
         };
     }
 
-    // During evening/night/morning: discharge to cover home demand
-    let hour = Local::now().hour();
+    discharge_or_idle(grid_power, solar_power, battery, hour, "")
+}
+
+fn discharge_or_idle(
+    grid_power: f64,
+    solar_power: f64,
+    battery: &BatteryState,
+    hour: u32,
+    extra_reason: &str,
+) -> ControlDecision {
     let is_discharge_period = !(DISCHARGE_END_HOUR..DISCHARGE_START_HOUR).contains(&hour);
 
     if is_discharge_period && grid_power > MIN_POWER_THRESHOLD as f64 {
         let demand = grid_power as i32;
-        let discharge_power = demand.min(limits.max_discharge_power);
+        let discharge_power = demand.min(battery.max_discharge_power);
+        let mut reason = format!("Discharge period (hour {hour}): grid demand {demand}W");
+        if !extra_reason.is_empty() {
+            reason = format!("{extra_reason}; {reason}");
+        }
         return ControlDecision {
             mode: ControlMode::Discharge,
             power_watts: discharge_power,
-            reason: format!("Discharge period (hour {hour}): grid demand {demand}W"),
+            reason,
             grid_power,
             solar_power,
         };
     }
 
+    let base = format!(
+        "No action needed (grid: {grid_power:.0}W, solar: {solar_power:.0}W, hour: {hour})"
+    );
+    let reason = if extra_reason.is_empty() {
+        base
+    } else {
+        format!("{extra_reason}; {base}")
+    };
+
     ControlDecision {
         mode: ControlMode::Idle,
         power_watts: 0,
-        reason: format!(
-            "No action needed (grid: {grid_power:.0}W, solar: {solar_power:.0}W, hour: {hour})"
-        ),
+        reason,
         grid_power,
         solar_power,
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn battery(soc: u32) -> BatteryState {
+        BatteryState {
+            soc,
+            max_discharge_power: 800,
+            max_charge_power: 2400,
+        }
+    }
+
+    /// Build a controller that has been in `mode` for the given duration.
+    fn controller_in_mode(mode: ControlMode, elapsed: Duration) -> Controller {
+        Controller {
+            last_mode: mode,
+            last_mode_change: Instant::now() - elapsed,
+            min_mode_duration: MIN_MODE_DURATION,
+        }
+    }
+
+    /// Build a controller with no cooldown (for tests that only care about raw logic).
+    fn controller_no_cooldown() -> Controller {
+        Controller {
+            last_mode: ControlMode::Idle,
+            last_mode_change: Instant::now() - MIN_MODE_DURATION,
+            min_mode_duration: Duration::ZERO,
+        }
+    }
+
+    // --- Raw decision logic tests ---
+
+    #[test]
+    fn soc_100_never_charges() {
+        let mut ctrl = controller_no_cooldown();
+        let decision = ctrl.decide_at_hour(-500.0, 600.0, &battery(100), 20);
+        assert_ne!(decision.mode, ControlMode::Charge);
+        assert!(decision.reason.contains("Battery full"));
+    }
+
+    #[test]
+    fn soc_100_can_still_discharge() {
+        let mut ctrl = controller_no_cooldown();
+        // Hour 20 is in discharge period
+        let decision = ctrl.decide_at_hour(400.0, 0.0, &battery(100), 20);
+        assert_eq!(decision.mode, ControlMode::Discharge);
+        assert!(decision.reason.contains("Battery full"));
+    }
+
+    #[test]
+    fn charges_on_solar_excess() {
+        let mut ctrl = controller_no_cooldown();
+        let decision = ctrl.decide_at_hour(-300.0, 400.0, &battery(50), 12);
+        assert_eq!(decision.mode, ControlMode::Charge);
+        assert_eq!(decision.power_watts, 300);
+    }
+
+    #[test]
+    fn charge_power_capped_by_battery_limit() {
+        let state = BatteryState {
+            soc: 50,
+            max_discharge_power: 800,
+            max_charge_power: 1000,
+        };
+        let mut ctrl = controller_no_cooldown();
+        let decision = ctrl.decide_at_hour(-1500.0, 2000.0, &state, 12);
+        assert_eq!(decision.mode, ControlMode::Charge);
+        assert_eq!(decision.power_watts, 1000);
+    }
+
+    #[test]
+    fn idle_within_threshold() {
+        let mut ctrl = controller_no_cooldown();
+        let decision = ctrl.decide_at_hour(30.0, 100.0, &battery(50), 12);
+        assert_eq!(decision.mode, ControlMode::Idle);
+    }
+
+    #[test]
+    fn discharge_capped_by_battery_limit() {
+        let state = BatteryState {
+            soc: 80,
+            max_discharge_power: 500,
+            max_charge_power: 2400,
+        };
+        let mut ctrl = controller_no_cooldown();
+        // Hour 20 = discharge period
+        let decision = ctrl.decide_at_hour(1000.0, 0.0, &state, 20);
+        assert_eq!(decision.mode, ControlMode::Discharge);
+        assert_eq!(decision.power_watts, 500);
+    }
+
+    #[test]
+    fn no_discharge_during_daytime() {
+        let mut ctrl = controller_no_cooldown();
+        let decision = ctrl.decide_at_hour(400.0, 200.0, &battery(80), 12);
+        assert_eq!(decision.mode, ControlMode::Idle);
+    }
+
+    // --- Anti-toggle / cooldown tests ---
+
+    #[test]
+    fn toggle_charge_to_discharge_suppressed_during_cooldown() {
+        // Was charging for 2 minutes — wants to switch to discharge
+        let mut ctrl = controller_in_mode(ControlMode::Charge, Duration::from_secs(120));
+        // Hour 20, importing 300W → raw decision would be Discharge
+        let decision = ctrl.decide_at_hour(300.0, 50.0, &battery(50), 20);
+        assert_eq!(decision.mode, ControlMode::Idle);
+        assert!(decision.reason.contains("Cooldown"));
+    }
+
+    #[test]
+    fn toggle_discharge_to_charge_suppressed_during_cooldown() {
+        // Was discharging for 1 minute — wants to switch to charge
+        let mut ctrl = controller_in_mode(ControlMode::Discharge, Duration::from_secs(60));
+        // Exporting 200W → raw decision would be Charge
+        let decision = ctrl.decide_at_hour(-200.0, 300.0, &battery(50), 20);
+        assert_eq!(decision.mode, ControlMode::Idle);
+        assert!(decision.reason.contains("Cooldown"));
+    }
+
+    #[test]
+    fn toggle_allowed_after_cooldown_expires() {
+        // Was charging for 6 minutes — cooldown (5 min) has passed
+        let mut ctrl = controller_in_mode(ControlMode::Charge, Duration::from_secs(360));
+        let decision = ctrl.decide_at_hour(300.0, 50.0, &battery(50), 20);
+        assert_eq!(decision.mode, ControlMode::Discharge);
+    }
+
+    #[test]
+    fn idle_to_charge_always_allowed() {
+        // Was idle for just 10 seconds — switching to charge should be fine
+        let mut ctrl = controller_in_mode(ControlMode::Idle, Duration::from_secs(10));
+        let decision = ctrl.decide_at_hour(-300.0, 400.0, &battery(50), 12);
+        assert_eq!(decision.mode, ControlMode::Charge);
+    }
+
+    #[test]
+    fn idle_to_discharge_always_allowed() {
+        let mut ctrl = controller_in_mode(ControlMode::Idle, Duration::from_secs(10));
+        let decision = ctrl.decide_at_hour(300.0, 0.0, &battery(50), 20);
+        assert_eq!(decision.mode, ControlMode::Discharge);
+    }
+
+    #[test]
+    fn charge_to_idle_always_allowed() {
+        // Was charging for 10 seconds — going idle is always safe
+        let mut ctrl = controller_in_mode(ControlMode::Charge, Duration::from_secs(10));
+        // No export, no import within threshold, daytime → Idle
+        let decision = ctrl.decide_at_hour(20.0, 100.0, &battery(50), 12);
+        assert_eq!(decision.mode, ControlMode::Idle);
+    }
+
+    #[test]
+    fn rapid_oscillation_stays_idle() {
+        // Simulate low solar causing grid power to bounce around ±60W
+        let mut ctrl = controller_in_mode(ControlMode::Idle, Duration::from_secs(0));
+        let bat = battery(50);
+
+        // First reading: slight export → charge
+        let d1 = ctrl.decide_at_hour(-60.0, 80.0, &bat, 20);
+        assert_eq!(d1.mode, ControlMode::Charge);
+
+        // Second reading 10s later: slight import → wants discharge, but cooldown blocks it
+        let d2 = ctrl.decide_at_hour(60.0, 20.0, &bat, 20);
+        assert_eq!(d2.mode, ControlMode::Idle, "should go idle, not discharge");
+        assert!(d2.reason.contains("Cooldown"));
+
+        // Third reading: back to export → wants charge again
+        // We're now idle (from suppression), so idle→charge is allowed
+        let d3 = ctrl.decide_at_hour(-60.0, 80.0, &bat, 20);
+        assert_eq!(d3.mode, ControlMode::Charge);
+
+        // Fourth: wants discharge again → suppressed (charge was just set)
+        let d4 = ctrl.decide_at_hour(60.0, 20.0, &bat, 20);
+        assert_eq!(d4.mode, ControlMode::Idle, "still suppressed");
     }
 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,3 +1,4 @@
+mod battery;
 mod config;
 mod controller;
 mod grid_power;
@@ -5,6 +6,7 @@ mod models;
 mod mqtt;
 mod zendure;
 
+use battery::Battery;
 use config::Config;
 use grid_power::{GridPowerEstimator, KwhDeltaEstimator};
 use mqtt::MqttEvent;
@@ -25,14 +27,17 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
         config.zendure_sn
     );
 
-    // Poll battery on startup to get actual device limits
+    // Poll battery on startup to get actual device state
     let zendure_client = zendure::ZendureClient::new(&config.zendure_ip, config.zendure_sn.clone());
-    let report = zendure_client.get_properties().await?;
-    let limits = controller::BatteryLimits::from_properties(&report.properties);
+    let battery_state = zendure_client
+        .get_state()
+        .await
+        .map_err(|e| e.to_string())?;
     tracing::info!(
-        "Battery limits: max_discharge={}W, SOC={}%",
-        limits.max_discharge_power,
-        report.properties.electric_level.unwrap_or(0),
+        "Battery: SOC={}%, max_discharge={}W, max_charge={}W",
+        battery_state.soc,
+        battery_state.max_discharge_power,
+        battery_state.max_charge_power,
     );
 
     let (mqtt_client, eventloop) = mqtt::create_mqtt_client(&config);
@@ -60,6 +65,7 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
     let mut latest_meter: Option<models::MeterReading> = None;
     let mut latest_solar_power: f64 = 0.0;
     let mut grid_estimator = KwhDeltaEstimator::new();
+    let mut ctrl = controller::Controller::new();
 
     tracing::info!("Coordinator running, waiting for MQTT data...");
 
@@ -87,7 +93,7 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
 
         let net_grid_power = grid_estimator.update(meter, latest_solar_power);
 
-        let decision = controller::decide(net_grid_power, latest_solar_power, &limits);
+        let decision = ctrl.decide(net_grid_power, latest_solar_power, &battery_state);
         tracing::info!(
             "Decision: {} at {}W — {} (net_grid={:.0}W)",
             decision.mode,


### PR DESCRIPTION
Extract battery state and control into a dedicated Battery trait with Zendure implementation and mock for testing. Make the controller stateful to prevent rapid charge↔discharge toggling.

* Add `src/battery.rs` with `BatteryState`, `BatteryError`, `Battery` trait, and mock
* Refactor controller into stateful `Controller` struct with 5-minute cooldown
* Skip charging when SOC is 100%, respect per-battery charge/discharge power limits
* Add tests for cooldown suppression, SOC handling, and rapid oscillation

[changelog]
Prevent rapid charge/discharge toggling with 5-minute cooldown between mode switches