### PR TITLE
Replace discharge time window with idle-before-discharge guard

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@ Smart controller for the Zendure AC 2400+ home battery. Reads net grid power fro
 2. **Polls the Zendure device** via its local REST API for battery state (SOC, power, temperatures, pack data)
 3. **Decides what the battery should do**:
    - **Charge** when there's excess solar being exported to the grid (up to 2400W)
-   - **Discharge** during evening/night/morning (17:00–07:00) to cover grid demand (up to inverter limit)
+   - **Discharge** to cover grid demand (up to inverter limit), after a configurable idle period to prevent charge/discharge oscillation
    - **Idle** otherwise
    - **Standby** after prolonged idle or when daily cycle limit is reached
 5. **Safety guards**:
@@ -54,7 +54,7 @@ All configuration is via environment variables:
 | Variable | Required | Default | Description |
 |----------|----------|---------|-------------|
 | `CHARGE_START_THRESHOLD` | No | `-100.0` | Grid power (W) below which charging starts. Negative = exporting |
-| `DISCHARGE_START_THRESHOLD` | No | `0.0` | Grid power (W) above which discharging starts during discharge hours |
+| `DISCHARGE_START_THRESHOLD` | No | `0.0` | Grid power (W) above which discharging starts |
 | `CHARGE_MARGIN` | No | `50` | Safety margin (W) subtracted from charge power to avoid grid import |
 | `DISCHARGE_MARGIN` | No | `5` | Safety margin (W) subtracted from discharge power |
 | `MIN_SOC` | No | `10` | Minimum SOC (%) — discharge is blocked at or below this level |
@@ -64,6 +64,7 @@ All configuration is via environment variables:
 
 | Variable | Required | Default | Description |
 |----------|----------|---------|-------------|
+| `MIN_IDLE_BEFORE_DISCHARGE` | No | `300` | Minimum seconds of idle before discharge is allowed (prevents charge→discharge oscillation) |
 | `MIN_MODE_DURATION` | No | `10` | Minimum seconds before a charge/discharge toggle is allowed |
 | `MIN_DECISION_INTERVAL` | No | `5` | Minimum seconds between any two decisions (API protection) |
 | `IDLE_TIMEOUT_MINUTES` | No | `5` | Minutes of continuous idle before entering standby |
@@ -74,7 +75,7 @@ All configuration is via environment variables:
 
 | Variable | Required | Default | Description |
 |----------|----------|---------|-------------|
-| `TIMEZONE` | No | `UTC` | IANA timezone for discharge window (e.g. `Europe/Amsterdam`) |
+| `TIMEZONE` | No | `UTC` | IANA timezone for cycle counting (e.g. `Europe/Amsterdam`) |
 | `RTE_STATE_PATH` | No | `/tmp/zendure_rte_state.json` | File path for persisting round-trip efficiency state across restarts |
 | `RUST_LOG` | No | — | Log level filter (e.g. `zendure=debug` for verbose output) |
 

--- a/src/config.rs
+++ b/src/config.rs
@@ -34,7 +34,9 @@ pub struct Config {
     pub min_soc: u32,
     /// Maximum SOC percentage before charging is blocked (default 100)
     pub max_soc: u32,
-    /// IANA timezone for discharge window evaluation (e.g. Europe/Amsterdam)
+    /// Minimum seconds of idle before discharge is allowed (prevents charge→discharge oscillation)
+    pub min_idle_before_discharge_secs: u64,
+    /// IANA timezone (e.g. Europe/Amsterdam)
     pub timezone: Tz,
     /// Seconds without MQTT updates before forcing idle (safety failsafe)
     pub mqtt_timeout_secs: u64,
@@ -107,6 +109,10 @@ impl Config {
                 .unwrap_or_else(|_| "100".to_string())
                 .parse::<u32>()
                 .map_err(|_| "MAX_SOC must be a number")?,
+            min_idle_before_discharge_secs: env::var("MIN_IDLE_BEFORE_DISCHARGE")
+                .unwrap_or_else(|_| "300".to_string())
+                .parse::<u64>()
+                .map_err(|_| "MIN_IDLE_BEFORE_DISCHARGE must be a number")?,
             timezone: env::var("TIMEZONE")
                 .unwrap_or_else(|_| "UTC".to_string())
                 .parse::<Tz>()

--- a/src/controller.rs
+++ b/src/controller.rs
@@ -8,8 +8,6 @@ use crate::config::Config;
 use crate::models::{ControlDecision, ControlMode, CycleCounts};
 
 const MAX_CHARGE_POWER: i32 = 2400;
-const DISCHARGE_START_HOUR: u32 = 17;
-const DISCHARGE_END_HOUR: u32 = 7;
 const RAMP_FACTOR: f64 = 0.75;
 
 pub struct Controller {
@@ -24,6 +22,7 @@ pub struct Controller {
     charge_start_threshold: f64,
     discharge_start_threshold: f64,
     idle_timeout: Duration,
+    min_idle_before_discharge: Duration,
     daily_transitions: u32,
     daily_cooldown_suppressions: u32,
     cycle_warn_threshold: u32,
@@ -49,6 +48,7 @@ impl Controller {
             charge_start_threshold: config.charge_start_threshold,
             discharge_start_threshold: config.discharge_start_threshold,
             idle_timeout: Duration::from_secs(config.idle_timeout_minutes * 60),
+            min_idle_before_discharge: Duration::from_secs(config.min_idle_before_discharge_secs),
             daily_transitions: 0,
             daily_cooldown_suppressions: 0,
             cycle_warn_threshold: config.cycle_warn_threshold,
@@ -116,9 +116,7 @@ impl Controller {
     /// aggressive than the threshold to *keep* doing so. This prevents
     /// oscillation when the battery's own grid effect pushes the meter reading
     /// close to the start threshold.
-    fn target_mode(&self, grid_power: f64, battery: &BatteryState, hour: u32) -> ControlMode {
-        let is_discharge_period = !(DISCHARGE_END_HOUR..DISCHARGE_START_HOUR).contains(&hour);
-
+    fn target_mode(&self, grid_power: f64, battery: &BatteryState, _hour: u32) -> ControlMode {
         // Adjust for battery's own grid effect: the meter reading includes
         // the battery's consumption (charging) or production (discharging).
         // current_power: negative = charging, positive = discharging.
@@ -147,11 +145,18 @@ impl Controller {
             self.discharge_start_threshold
         };
 
-        // Importing from grid during discharge hours and battery above min SOC → discharge
-        if is_discharge_period
-            && battery.soc > self.min_soc
-            && underlying_grid > discharge_threshold
-        {
+        // Require minimum idle duration before starting discharge (prevents
+        // charge→idle→discharge oscillation during variable solar conditions).
+        // Already-discharging is exempt (hysteresis keeps it going).
+        let idle_long_enough = match self.last_mode {
+            ControlMode::Discharge => true,
+            _ => self
+                .last_idle_start
+                .is_some_and(|t| t.elapsed() >= self.min_idle_before_discharge),
+        };
+
+        // Importing from grid and battery above min SOC → discharge
+        if idle_long_enough && battery.soc > self.min_soc && underlying_grid > discharge_threshold {
             return ControlMode::Discharge;
         }
 
@@ -364,6 +369,7 @@ mod tests {
             charge_start_threshold: -100.0,
             discharge_start_threshold: 0.0,
             idle_timeout: Duration::from_secs(5 * 60),
+            min_idle_before_discharge: Duration::from_secs(300),
             daily_transitions: 0,
             daily_cooldown_suppressions: 0,
             cycle_warn_threshold: 200,
@@ -374,10 +380,13 @@ mod tests {
         }
     }
 
-    /// Controller with no cooldown (for tests that only care about mode/power logic).
+    /// Controller with no cooldown and no idle-before-discharge requirement
+    /// (for tests that only care about mode/power logic).
     fn controller_no_cooldown() -> Controller {
         Controller {
             min_mode_duration: Duration::ZERO,
+            min_idle_before_discharge: Duration::ZERO,
+            last_idle_start: Some(Instant::now() - Duration::from_secs(60)),
             ..default_controller()
         }
     }
@@ -387,10 +396,9 @@ mod tests {
         Controller {
             last_mode: mode,
             last_mode_change: Instant::now() - elapsed,
-            last_idle_start: if mode == ControlMode::Idle {
-                Some(Instant::now() - elapsed)
-            } else {
-                None
+            last_idle_start: match mode {
+                ControlMode::Idle | ControlMode::Standby => Some(Instant::now() - elapsed),
+                _ => None,
             },
             ..default_controller()
         }
@@ -468,16 +476,37 @@ mod tests {
     fn idle_within_deadband() {
         let mut ctrl = controller_no_cooldown();
         // 0W is at discharge_start_threshold (0W) and above charge_start_threshold (-100W)
-        // During daytime (hour 12), discharge is blocked regardless
         let decision = ctrl.decide_at_hour(0.0, &battery(50), 12);
         assert_eq!(decision.mode, ControlMode::Idle);
     }
 
     #[test]
-    fn no_discharge_during_daytime() {
+    fn no_discharge_before_idle_duration_met() {
         let mut ctrl = controller_no_cooldown();
+        // Recently went idle — not idle long enough for discharge
+        ctrl.last_idle_start = Some(Instant::now() - Duration::from_secs(60));
+        ctrl.min_idle_before_discharge = Duration::from_secs(300);
         let decision = ctrl.decide_at_hour(400.0, &battery(80), 12);
         assert_eq!(decision.mode, ControlMode::Idle);
+    }
+
+    #[test]
+    fn discharge_allowed_after_idle_duration_met() {
+        let mut ctrl = controller_no_cooldown();
+        // Idle for long enough
+        ctrl.last_idle_start = Some(Instant::now() - Duration::from_secs(600));
+        ctrl.min_idle_before_discharge = Duration::from_secs(300);
+        let decision = ctrl.decide_at_hour(400.0, &battery(80), 12);
+        assert_eq!(decision.mode, ControlMode::Discharge);
+    }
+
+    #[test]
+    fn discharge_allowed_when_already_discharging() {
+        // Already discharging — should keep going regardless of idle duration
+        let mut ctrl = controller_in_mode(ControlMode::Discharge, Duration::from_secs(60));
+        ctrl.min_idle_before_discharge = Duration::from_secs(300);
+        let decision = ctrl.decide_at_hour(400.0, &battery(80), 12);
+        assert_eq!(decision.mode, ControlMode::Discharge);
     }
 
     #[test]
@@ -648,11 +677,11 @@ mod tests {
     // --- Cooldown tests ---
 
     #[test]
-    fn toggle_charge_to_discharge_suppressed() {
+    fn charge_to_discharge_blocked_by_idle_duration() {
+        // In Charge mode → target_mode returns Idle (no idle time for discharge)
         let mut ctrl = controller_in_mode(ControlMode::Charge, Duration::from_secs(5));
         let decision = ctrl.decide_at_hour(300.0, &battery(50), 20);
         assert_eq!(decision.mode, ControlMode::Idle);
-        assert!(decision.reason.contains("Cooldown"));
     }
 
     #[test]
@@ -664,8 +693,9 @@ mod tests {
     }
 
     #[test]
-    fn toggle_allowed_after_cooldown_expires() {
-        let mut ctrl = controller_in_mode(ControlMode::Charge, Duration::from_secs(15));
+    fn discharge_allowed_after_sufficient_idle() {
+        // Was in Charge, then idle for 10 minutes (> 5 min default)
+        let mut ctrl = controller_in_mode(ControlMode::Idle, Duration::from_secs(600));
         let decision = ctrl.decide_at_hour(300.0, &battery(50), 20);
         assert_eq!(decision.mode, ControlMode::Discharge);
     }
@@ -678,8 +708,8 @@ mod tests {
     }
 
     #[test]
-    fn idle_to_discharge_always_allowed() {
-        let mut ctrl = controller_in_mode(ControlMode::Idle, Duration::from_secs(1));
+    fn idle_to_discharge_allowed_after_idle_duration() {
+        let mut ctrl = controller_in_mode(ControlMode::Idle, Duration::from_secs(600));
         let decision = ctrl.decide_at_hour(300.0, &battery(50), 20);
         assert_eq!(decision.mode, ControlMode::Discharge);
     }
@@ -694,20 +724,25 @@ mod tests {
     #[test]
     fn rapid_oscillation_stays_idle() {
         let mut ctrl = controller_in_mode(ControlMode::Idle, Duration::from_secs(0));
+        ctrl.min_idle_before_discharge = Duration::from_secs(300);
         let bat = battery(50);
 
         let d1 = ctrl.decide_at_hour(-200.0, &bat, 20);
         assert_eq!(d1.mode, ControlMode::Charge);
 
+        // After charging, idle duration not met → stays idle (not discharge)
         let d2 = ctrl.decide_at_hour(200.0, &bat, 20);
         assert_eq!(d2.mode, ControlMode::Idle, "should go idle, not discharge");
-        assert!(d2.reason.contains("Cooldown"));
 
         let d3 = ctrl.decide_at_hour(-200.0, &bat, 20);
         assert_eq!(d3.mode, ControlMode::Charge);
 
         let d4 = ctrl.decide_at_hour(200.0, &bat, 20);
-        assert_eq!(d4.mode, ControlMode::Idle, "still suppressed");
+        assert_eq!(
+            d4.mode,
+            ControlMode::Idle,
+            "still idle, not enough idle time"
+        );
     }
 
     // --- Standby tests ---
@@ -716,7 +751,8 @@ mod tests {
     fn idle_timeout_triggers_standby() {
         let mut ctrl = controller_in_mode(ControlMode::Idle, Duration::from_secs(16 * 60));
         ctrl.idle_timeout = Duration::from_secs(15 * 60);
-        let decision = ctrl.decide_at_hour(20.0, &battery(50), 12);
+        // Grid at 0W — no discharge demand, so idle persists until standby triggers
+        let decision = ctrl.decide_at_hour(0.0, &battery(50), 12);
         assert_eq!(decision.mode, ControlMode::Standby);
         assert!(decision.reason.contains("standby"));
     }
@@ -761,10 +797,11 @@ mod tests {
 
     #[test]
     fn cooldown_suppression_increments_counter() {
-        let mut ctrl = controller_in_mode(ControlMode::Charge, Duration::from_secs(5));
+        // Discharge→Charge toggle within cooldown
+        let mut ctrl = controller_in_mode(ControlMode::Discharge, Duration::from_secs(5));
         assert_eq!(ctrl.daily_cooldown_suppressions, 0);
 
-        ctrl.decide_at_hour(300.0, &battery(50), 20);
+        ctrl.decide_at_hour(-200.0, &battery(50), 20);
         assert_eq!(ctrl.daily_cooldown_suppressions, 1);
         // Suppression doesn't count as a transition
         assert_eq!(ctrl.daily_transitions, 0);
@@ -1034,18 +1071,18 @@ mod tests {
         assert_eq!(decision.mode, ControlMode::Discharge);
     }
 
-    /// Simulates a nighttime discharge scenario with Shelly Pro 3EM providing
+    /// Simulates a discharge scenario with Shelly Pro 3EM providing
     /// direct signed grid power every second.
     ///
-    /// Scenario: 04:00, no solar production. House consuming 150W.
+    /// Scenario: House consuming 150W, battery idle long enough.
     /// The battery should ramp up from idle to ~150W discharge, covering the
     /// house demand and bringing net grid power close to zero.
     #[test]
-    fn nighttime_discharge_converges_to_house_consumption() {
+    fn discharge_converges_to_house_consumption() {
         let mut ctrl = controller_no_cooldown();
 
         let house_total = 150.0_f64;
-        let hour = 4; // Discharge period (outside 07:00–17:00)
+        let hour = 12;
 
         // Step 1: Battery idle, house importing 150W from grid.
         let d1 = ctrl.decide_at_hour(150.0, &battery(80), hour);


### PR DESCRIPTION
Remove the fixed 17:00–07:00 discharge window and replace it with a configurable minimum idle duration before discharge is allowed. This enables discharge at any hour while preventing charge→idle→discharge oscillation during variable solar conditions.

* Remove DISCHARGE_START_HOUR/DISCHARGE_END_HOUR constants
* Add MIN_IDLE_BEFORE_DISCHARGE config (default 300s)
* Discharge requires idle for configured duration, or already discharging
* Update tests and README

[changelog]
Discharge is no longer restricted to evening/night hours. Instead, the battery must be idle for a configurable period (default 5 minutes) before discharging, preventing oscillation during variable solar conditions.